### PR TITLE
Expand image button on images with bigger-image

### DIFF
--- a/newsroom/templates/newsroom/article.css
+++ b/newsroom/templates/newsroom/article.css
@@ -1,4 +1,3 @@
-
 .article-content {
     width: 70%;
     margin-top: 30px;
@@ -537,6 +536,43 @@ article figure, article p.caption {
 .embed-responsive-16by9 {
     margin-top: 12px;
 
+}
+
+.bigger-image {
+    position: relative;
+    display: inline-block;
+}
+
+.bigger-image:after {
+    content: '';
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 28px;
+    height: 28px;
+    background: rgba(0,0,0,0.5);
+    border-radius: 3px;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.bigger-image:before {
+    content: '';
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 16px;
+    height: 16px;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='-3 -3 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23ffffff' d='M23 8.75V1.5l-.5-.5h-7.25v1.25l4.5.6L14 8.575 15.4 10l5.75-5.725.6 4.475zm-22 6.5v7.25l.475.5h7.25v-1.25l-4.475-.6 5.725-5.775L8.6 14l-5.775 5.725-.575-4.475z'/%3E%3C/svg%3E");
+    background-size: contain;
+    z-index: 1; 
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.bigger-image:hover:after,
+.bigger-image:hover:before {
+    opacity: 1;
 }
 
 {% if article.undistracted_layout %}

--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -249,11 +249,13 @@ def linkImages(soup):
                 img.parent["href"] = urlnew
                 img.parent["class"] = "bigger-image"
                 img.parent["target"] = "_blank"
+                img["style"] = "cursor: pointer;"
             else:
                 link = soup.new_tag("a")
                 link["href"] = urlnew
                 link["target"] = "_blank"
                 link["class"] = "bigger-image"
+                img["style"] = "cursor: pointer;"
                 img.wrap(link)
         return soup
     # This code is not important enough to be worth crashing the site on


### PR DESCRIPTION
Addresses #56

Button only shows on images with the class `bigger-image`. 
Changes cursor to a pointer on image hover as well, similar to The Guardian's implementation. 

Passes tests.