### PR TITLE
Fixed q&a pagination -- search context now added to query

### DIFF
--- a/agony/templates/agony/qanda_list.html
+++ b/agony/templates/agony/qanda_list.html
@@ -72,7 +72,9 @@
                         {% endif %}
                     </div>
                 {% endfor %}
-                {% include "paginator.html" %}
+                {% with query_params=query_params %}
+                    {% include "paginator.html" %}
+                {% endwith %}
             </div>
         </div>
     </div>

--- a/agony/views.py
+++ b/agony/views.py
@@ -34,19 +34,33 @@ class QandAList(ListView):
     def get_context_data(self, **kwargs):
         context = super(QandAList, self).get_context_data(**kwargs)
         context['qanda_search'] = True
-        if self.request.user.has_perm('agony.change_qanda'):
-            context['can_edit'] = True
-        else:
-            context['can_edit'] = False
+        
+        # query params dict for context -- needed for pagination
+        query_params = {}
         if 'topic' in self.request.GET:
+            query_params['topic'] = self.request.GET['topic']
             try:
                 topic = int(self.request.GET['topic'])
                 topic = Topic.objects.get(pk=topic)
                 context['topic'] = topic.name
             except:
                 pass
+
         if 'qanda_search_str' in self.request.GET:
+            query_params.update({
+                'qanda_search_str': self.request.GET['qanda_search_str'],
+                'search_type': self.request.GET.get('search_type', ''),
+                'is_simple': self.request.GET.get('is_simple', '')
+            })
             context['qanda_search_str'] = self.request.GET['qanda_search_str']
+
+        context['query_params'] = query_params
+        
+        if self.request.user.has_perm('agony.change_qanda'):
+            context['can_edit'] = True
+        else:
+            context['can_edit'] = False
+
         return context
 
 class QandADetail(DetailView):

--- a/templates/paginator.html
+++ b/templates/paginator.html
@@ -3,10 +3,10 @@
 	<ul class="pagination">
 		{% if page_obj.has_previous %}
 		<li>
-			<a href="?page=1">first</a>
+			<a href="?page=1{% for key, value in query_params.items %}&{{ key }}={{ value }}{% endfor %}">first</a>
 		</li>
 		<li>
-			<a href="?page={{ page_obj.previous_page_number }}{{ additional_parameters }}">previous</a>
+			<a href="?page={{ page_obj.previous_page_number }}{% for key, value in query_params.items %}&{{ key }}={{ value }}{% endfor %}">previous</a>
 		</li>
 		{% endif %}
 
@@ -19,10 +19,10 @@
 
 		{% if page_obj.has_next %}
 		<li>
-			<a href="?page={{ page_obj.next_page_number }}{{ additional_parameters }}">next</a>
+			<a href="?page={{ page_obj.next_page_number }}{% for key, value in query_params.items %}&{{ key }}={{ value }}{% endfor %}">next</a>
 		</li>
 		<li>
-			<a href="?page=last{{ additional_parameters }}">last</a>
+			<a href="?page=last{% for key, value in query_params.items %}&{{ key }}={{ value }}{% endfor %}">last</a>
 		</li>
 		{% endif %}
 	</ul>


### PR DESCRIPTION
Addresses #46 

Added search context so that the search / topic persists when changing pages using the paginator buttons.
Passes all tests.