### PR TITLE
bigger-image scaling fix in full-width mode

### DIFF
--- a/newsroom/templates/newsroom/article.css
+++ b/newsroom/templates/newsroom/article.css
@@ -651,6 +651,15 @@ article figure, article p.caption {
         line-height: 3.3rem;
     }
 
+    .bigger-image {
+        display: block;
+        width: 100%;
+    }
+    .bigger-image img {
+        width: 100%;
+        height: auto;
+    }
+
 }
 
 {% endif %}


### PR DESCRIPTION
Fixes bug introduced with #59 
Images now scale properly in full-width mode

Fix looks like this:
![image](https://github.com/user-attachments/assets/3d677eb4-b6d1-4078-a046-9a52e781d992)
