### PR TITLE
removed padding + font-size for fullwidth articles

### DIFF
--- a/newsroom/templates/newsroom/article.css
+++ b/newsroom/templates/newsroom/article.css
@@ -637,9 +637,6 @@ article figure, article p.caption {
     .article p.caption {
         margin-left: -1px;
         margin-right: -1px;
-        padding-left: 100px !important;
-        padding-right: 100px !important;
-        font-size: 2.2rem !important;
     }
     .article__title {
         font-size: 4.7rem;


### PR DESCRIPTION
Fixed #74;

Removed old code that caused a bigger font size + padding.

Before:
![image](https://github.com/user-attachments/assets/e8d36e0b-6a79-49dd-90d3-2e873ad068fa)


After:
![image](https://github.com/user-attachments/assets/ef530baf-c710-4ca2-a2dc-a6657258559f)
