### PR TITLE
add default logo path in banner

### DIFF
--- a/templates/banner.html
+++ b/templates/banner.html
@@ -4,7 +4,7 @@
     <div class="container">
         <span id="logo">
             <a href="{% url 'newsroom:home' %}">
-                <img src="{% static logo %}" alt="GroundUp Logo" />
+                <img src="{% static logo|default:'newsroom/images/Logo_white.png' %}" alt="GroundUp Logo" />
             </a>
         </span>
         {% block mainmenu %}


### PR DESCRIPTION
Addresses #77
Fixed by adding a default logo path.

Before: 
![image](https://github.com/user-attachments/assets/b9d627c5-7126-4aa1-a921-5cae00a98664)

After: 
![image](https://github.com/user-attachments/assets/fc68421a-d8f5-4e25-accf-cc02fcdd1281)
