### PR TITLE
fix scaling on low res media

### DIFF
--- a/newsroom/templates/newsroom/article.css
+++ b/newsroom/templates/newsroom/article.css
@@ -541,6 +541,7 @@ article figure, article p.caption {
 .bigger-image {
     position: relative;
     display: inline-block;
+    width: 100%;
 }
 
 .bigger-image:after {


### PR DESCRIPTION
Fixes the scaling of bigger-image when the image has a low resolution.

Before:
![image](https://github.com/user-attachments/assets/4a20800c-fe4d-4528-8f82-7978aa4a43ac)


After:
![image](https://github.com/user-attachments/assets/b0792222-0e88-405d-82e0-f98245a45b93)
