### PR TITLE
Remove "we regret that" for clarity

### DIFF
--- a/letters/templates/letters/rejected_letter.html
+++ b/letters/templates/letters/rejected_letter.html
@@ -20,7 +20,7 @@ The title of your letter is:<br />
 
 
 <p>
-After carefully considering your letter, we regret that we have decided not to
+After carefully considering your letter, we have decided not to
 publish it.
 </p>
 


### PR DESCRIPTION
Addresses & closes #117 

Rejection email now reads "After carefully considering your letter, we have decided not to publish it." instead of "After carefully considering your letter, **we regret that** we have decided not to publish it."