### PR TITLE
Query Strings: Default to empty string instead of none if not present

### DIFF
--- a/newsroom/views.py
+++ b/newsroom/views.py
@@ -787,7 +787,7 @@ def logout_from_all_sessions(request):
 
 def advanced_search(request):
     page = None
-    query = request.GET.get('adv_search')
+    query = request.GET.get('adv_search', '')
     search_type = request.GET.get('search_type')
     first_author = request.GET.get('first_author')
     first_author_only = True if first_author == "on" else False


### PR DESCRIPTION
This fixes the HTTP 500 error when going to the second page of an advanced search with a blank query. 
(Addresses & closes #116)

