### PR TITLE
Add a donation button to Q&A answers

### DIFF
--- a/agony/templates/agony/qanda_detail.html
+++ b/agony/templates/agony/qanda_detail.html
@@ -48,6 +48,12 @@
                         {% endif %}
                     </div>
                 {% endif %}
+
+                <div style="text-align: center; margin: 20px 0; padding: 15px; border-top: 1px solid #eee; border-bottom: 1px solid #eee;">
+                    <p>If you found this answer useful, please consider donating to GroundUp.</p>
+                    <a href="/donation/payfast/" class="btn btn-primary btn-lg">Donate</a>
+                </div>
+
                 <p id="qand__disclaimer">
                     Please note: GroundUp is just a news agency. 
                     We are not lawyers or financial advisors, 


### PR DESCRIPTION
Adds a donation button at the bottom of all agony answers, but above the disclaimer.
See below:

<img width="732" height="730" alt="image" src="https://github.com/user-attachments/assets/51b58470-5b88-49fd-b2eb-7459dce80283" />
