### PR TITLE
fix: render republisher form as paragraphs in article block template

### DIFF
--- a/newsroom/templates/newsroom/article_block.html
+++ b/newsroom/templates/newsroom/article_block.html
@@ -552,7 +552,7 @@
                 {{ republisherFormSet.management_form }}
                 {% for form in republisherFormSet %}
                     <div class="republisher-form inline-form">
-                        {{form}}
+                        {{form.as_p}}
                     </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
Fixes bug whereby some tags are not closed properly