### PR TITLE
Remove Django-Allauth-2fa & Django-otp

### DIFF
--- a/groundup/settings.py
+++ b/groundup/settings.py
@@ -61,15 +61,7 @@ INSTALLED_APPS = (
     "allauth.account",
     "allauth.socialaccount",
     "allauth.mfa",
-    # django_otp and allauth_2fa are kept until the 2FA data migration has been
-    # run on production (newsroom.0050_migrate_2fa_to_allauth_mfa). After running
-    # `manage.py migrate` on production, comment these out and remove the
-    # django-allauth-2fa and django-otp packages from requirements.txt.
-    "django_otp",
-    "django_otp.plugins.otp_totp",
-    "django_otp.plugins.otp_static",
     "debug_toolbar",
-    "allauth_2fa",
     "haystack",
     "compressor",
     "ajax_select",
@@ -98,13 +90,6 @@ MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    # Configure the django-otp package. Note this must be after the
-    # AuthenticationMiddleware.
-    "django_otp.middleware.OTPMiddleware",
-    # Reset login flow middleware. If this middleware is included, the login
-    # flow is reset if another page is loaded between login and successfully
-    # entering two-factor credentials.
-    "allauth_2fa.middleware.AllauthTwoFactorMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     # SessionAuthenticationMiddleware is deprecated

--- a/newsroom/migrations/0050_migrate_2fa_to_allauth_mfa.py
+++ b/newsroom/migrations/0050_migrate_2fa_to_allauth_mfa.py
@@ -12,27 +12,42 @@ def migrate_totp_secrets(apps, schema_editor):
     django_otp stores the key as a hex-encoded string.
     allauth.mfa stores the secret as base32 in a JSON data field.
     """
-    TOTPDevice = apps.get_model("otp_totp", "TOTPDevice")
     Authenticator = apps.get_model("mfa", "Authenticator")
+    connection = schema_editor.connection
+
+    if "otp_totp_totpdevice" not in connection.introspection.table_names():
+        print("\n2FA migration: no django-otp TOTP table found; skipped.")
+        return
 
     migrated = 0
     skipped = 0
 
-    for device in TOTPDevice.objects.filter(confirmed=True):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT user_id, key
+            FROM otp_totp_totpdevice
+            WHERE confirmed = %s
+            """,
+            [True],
+        )
+        devices = cursor.fetchall()
+
+    for user_id, key in devices:
         # conv hex key -> raw bytes -> base32 string
         try:
-            secret_b32 = base64.b32encode(binascii.unhexlify(device.key)).decode("ascii")
+            secret_b32 = base64.b32encode(binascii.unhexlify(key)).decode("ascii")
         except (binascii.Error, ValueError):
             skipped += 1
             continue
 
         # we skip if curr user already has a TOTP authenticator (avoid duplicates)
-        if Authenticator.objects.filter(user=device.user, type="totp").exists():
+        if Authenticator.objects.filter(user_id=user_id, type="totp").exists():
             skipped += 1
             continue
 
         Authenticator.objects.create(
-            user=device.user,
+            user_id=user_id,
             type="totp",
             data={"secret": secret_b32},
         )
@@ -45,7 +60,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("newsroom", "0049_alter_article_copyright"),
-        ("otp_totp", "__first__"),
         ("mfa", "__first__"),
     ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,12 +21,6 @@ python-dateutil
 piexif
 django-allauth
 fido2
-# django-allauth-2fa and django-otp are kept until the 2FA data migration
-# (newsroom.0050_migrate_2fa_to_allauth_mfa) has been run on production.
-# After `manage.py migrate` on production, remove allauth2fa & otp
-# comment out django_otp/allauth_2fa from INSTALLED_APPS in settings.py.
-django-allauth-2fa
-django-otp
 smartypants
 django-ajax-selects
 django-debug-toolbar

--- a/security/tests.py
+++ b/security/tests.py
@@ -27,3 +27,21 @@ class URLSWork(TestCase):
         response = c.get(url)
         self.assertEqual(response.status_code, 200, 
                         "Password change URL should be accessible")
+
+    def test_allauth_login_accepts_email_address(self):
+        """Users can sign in with their email address on the allauth login form."""
+        User.objects.create_user("admin", "admin@example.com", "abcde")
+
+        response = self.client.post(
+            reverse("account_login"),
+            {
+                "login": "admin@example.com",
+                "password": "abcde",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            int(self.client.session["_auth_user_id"]),
+            User.objects.get(username="admin").pk,
+        )


### PR DESCRIPTION
This allows Django-Allauth to upgrade to the latest version. It was previously held back by the old packages that still sat in the codebase.