### PR TITLE
Enhance SEO with breadcrumb navigation and structured data

### DIFF
--- a/newsroom/models.py
+++ b/newsroom/models.py
@@ -697,6 +697,23 @@ class Article(models.Model):
         else:
             return "Text by " + names[0] + ". Photos by " + names[1] + "."
 
+    def get_authors(self):
+        """Return nonnull author objects
+
+        Used to build the NewsArticle structured author list.
+        """
+        return [
+            author
+            for author in (
+                self.author_01,
+                self.author_02,
+                self.author_03,
+                self.author_04,
+                self.author_05,
+            )
+            if author is not None
+        ]
+
     """Gets only the necessary part of primary image by URL. i.e. it removes
     the domain if the domain is in ALLOWED_HOSTS.
     """

--- a/newsroom/templates/newsroom/article.css
+++ b/newsroom/templates/newsroom/article.css
@@ -678,3 +678,41 @@ article figure, article p.caption {
 }
 
 {% endif %}
+
+/* SEO breadcrumb navigation */
+.gu-breadcrumbs {
+    display: none;
+}
+
+.gu-breadcrumbs ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.gu-breadcrumbs li {
+    display: inline-flex;
+    align-items: center;
+}
+
+.gu-breadcrumbs li + li::before {
+    content: "\203A";
+    margin: 0 8px;
+    color: #999;
+}
+
+.gu-breadcrumbs a {
+    color: #4D4D4D;
+    text-decoration: none;
+}
+
+.gu-breadcrumbs a:hover {
+    text-decoration: underline;
+}
+
+.gu-breadcrumbs [aria-current="page"] {
+    color: #999;
+}

--- a/newsroom/templates/newsroom/article_block.html
+++ b/newsroom/templates/newsroom/article_block.html
@@ -57,6 +57,7 @@
             {% endfor %}
         </div>
     {% endif %}
+    {% include "seo/breadcrumbs.html" %}
     <h1 id="article_title" class="article__title {% if can_edit %} editable {% endif %}"
         {% if can_edit %}
         style="display:inline-block"

--- a/newsroom/templates/newsroom/article_detail.html
+++ b/newsroom/templates/newsroom/article_detail.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load fb_versions %}
+{% load seo_tags %}
 
 {% block title %}
     {{article.title|striptags|safe}}{{block.super}}
@@ -41,6 +42,8 @@
     <meta property="article:published_time" content="{{article.published|date:'c'}}"/>
     <meta property="article:modified_time" content="{{article.modified|date:'c'}}"/>
     <meta name="author" content="{{ article.cached_byline_no_links }}">
+
+    {% news_article_jsonld article %}
 
 {% endblock %}
 

--- a/newsroom/templates/newsroom/article_list.html
+++ b/newsroom/templates/newsroom/article_list.html
@@ -8,6 +8,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12 topic-intro">
+                {% include "seo/breadcrumbs.html" %}
                 {% block content-intro %}
                     <div>
 	                {% if heading %}

--- a/newsroom/templates/newsroom/author_detail.html
+++ b/newsroom/templates/newsroom/author_detail.html
@@ -8,6 +8,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
+                {% include "seo/breadcrumbs.html" %}
 		<h1 style="text-align: center;">
 		    Articles for {{author}}
 		</h1>

--- a/newsroom/templates/newsroom/topic_detail.html
+++ b/newsroom/templates/newsroom/topic_detail.html
@@ -7,6 +7,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
+                {% include "seo/breadcrumbs.html" %}
                 {% if request.user.is_authenticated and perms.newsroom.change_topic %}
                     <div class="topic-edit-action" style="float:right; margin:10px 0;">
                         <a href="{% url 'admin:newsroom_topic_change' topic.pk %}" class="btn btn-sm btn-primary">Edit topic</a>

--- a/newsroom/templatetags/seo_tags.py
+++ b/newsroom/templatetags/seo_tags.py
@@ -1,0 +1,176 @@
+"""SEO structured data template tags
+
+  - BreadcrumbList  (https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)
+  - NewsArticle     (https://developers.google.com/search/docs/appearance/structured-data/article)
+  - Organization    (used site-wide and as the NewsArticle publisher)
+
+All tags take the template context so they can resolve absolute URLs from the
+current request. JSON is escaped so it can never break out of the <script> block.
+"""
+
+import json
+
+from django import template
+from django.templatetags.static import static
+from django.utils.html import strip_tags
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+# org details; reused as NewsArticle publisher.
+ORG_NAME = "GroundUp"
+ORG_LOGO = "newsroom/images/LogoFiles/Logos20180905/MasterLogo.png"
+ORG_LOGO_WIDTH = 2000
+ORG_LOGO_HEIGHT = 403
+ORG_SAME_AS = [
+    "https://twitter.com/GroundUp_News",
+    "https://www.facebook.com/GroundUpNews",
+    "https://www.instagram.com/groundup_news/",
+    "https://www.tiktok.com/@groundup_news",
+]
+ORG_PUBLISHING_PRINCIPLES = "https://groundup.org.za/about/"
+ORG_ETHICS_POLICY = "https://groundup.org.za/ethics_and_style/"
+ORG_CORRECTIONS_POLICY = "https://groundup.org.za/correction/list/"
+ORG_MASTHEAD = "https://groundup.org.za/journalists/"
+
+
+def _ld_script(data):
+    """dict -> a safe <script type="application/ld+json"> block"""
+    payload = json.dumps(data, ensure_ascii=False)
+    # Prevent the JSON from terminating the <script> element or being parsed as html
+    payload = (
+        payload.replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+    return mark_safe(
+        '<script type="application/ld+json">' + payload + "</script>"
+    )
+
+
+def _abs(request, url):
+    """Make a relative path/URL absolute using current request"""
+    if not url:
+        return url
+    return request.build_absolute_uri(url)
+
+
+def _org_id(request):
+    return _abs(request, "/").rstrip("/") + "#publisher"
+
+
+def _publisher_ref(request):
+    return {"@id": _org_id(request), "name": ORG_NAME}
+
+
+def _organization_full(request):
+    """Full NewsMediaOrganization object for the standalone JSON-LD block."""
+    logo_url = _abs(request, static(ORG_LOGO))
+    return {
+        "@type": "NewsMediaOrganization",
+        "@id": _org_id(request),
+        "name": ORG_NAME,
+        "url": _abs(request, "/"),
+        "logo": {
+            "@type": "ImageObject",
+            "url": logo_url,
+            "contentUrl": logo_url,
+            "width": ORG_LOGO_WIDTH,
+            "height": ORG_LOGO_HEIGHT,
+        },
+        "sameAs": ORG_SAME_AS,
+        "publishingPrinciples": ORG_PUBLISHING_PRINCIPLES,
+        "ethicsPolicy": ORG_ETHICS_POLICY,
+        "correctionsPolicy": ORG_CORRECTIONS_POLICY,
+        "masthead": ORG_MASTHEAD,
+        "ownershipFundingInfo": _abs(request, "/funders"),
+    }
+
+
+@register.simple_tag(takes_context=True)
+def organization_jsonld(context):
+    request = context.get("request")
+    if request is None:
+        return ""
+    data = {"@context": "https://schema.org"}
+    data.update(_organization_full(request))
+    return _ld_script(data)
+
+
+@register.simple_tag(takes_context=True)
+def breadcrumb_jsonld(context, breadcrumbs):
+    """Render a BreadcrumbList from a list of {"name", "url"} dicts"""
+    request = context.get("request")
+    if not breadcrumbs or request is None:
+        return ""
+    items = []
+    for position, crumb in enumerate(breadcrumbs, start=1):
+        item = {
+            "@type": "ListItem",
+            "position": position,
+            "name": crumb["name"],
+        }
+        if crumb.get("url"):
+            item["item"] = _abs(request, crumb["url"])
+        items.append(item)
+    data = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": items,
+    }
+    return _ld_script(data)
+
+
+@register.simple_tag(takes_context=True)
+def news_article_jsonld(context, article):
+    request = context.get("request")
+    if request is None or article is None:
+        return ""
+
+    # Images (absolute, de-duplicated, blanks skipped)
+    images = []
+    for img in (article.cached_primary_image, article.cached_summary_image):
+        if img:
+            url = _abs(request, img)
+            if url not in images:
+                images.append(url)
+
+    # Authors: we pref real Person objects with profile pages
+    authors = [
+        {
+            "@type": "Person",
+            "name": str(author),
+            "url": _abs(request, author.get_absolute_url()),
+        }
+        for author in article.get_authors()
+    ]
+    if not authors and article.cached_byline_no_links:
+        name = article.cached_byline_no_links
+        if name.startswith("By "):
+            name = name[3:]
+        authors = [{"@type": "Person", "name": name}]
+
+    data = {
+        "@context": "https://schema.org",
+        "@type": "NewsArticle",
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": _abs(request, article.get_absolute_url()),
+        },
+        "headline": strip_tags(article.title),
+        "publisher": _publisher_ref(request),
+    }
+    if article.cached_summary_text_no_html:
+        data["description"] = article.cached_summary_text_no_html
+    if images:
+        data["image"] = images
+    if article.published:
+        data["datePublished"] = article.published.isoformat()
+    if article.modified:
+        data["dateModified"] = article.modified.isoformat()
+    if authors:
+        data["author"] = authors
+    if article.category_id:
+        data["articleSection"] = article.category.name
+
+    return _ld_script(data)

--- a/newsroom/views.py
+++ b/newsroom/views.py
@@ -522,6 +522,11 @@ class AuthorDetail(ArticleList):
         context["image"] = self.author.photo
         context["description"] = self.author.description
         context["author"] = self.author
+        context["breadcrumbs"] = [
+            {"name": "Home", "url": "/"},
+            {"name": "Authors", "url": reverse("newsroom:author.list")},
+            {"name": str(self.author), "url": self.author.get_absolute_url()},
+        ]
         return context
 
 
@@ -537,6 +542,13 @@ class CategoryDetail(ArticleList):
     def get_context_data(self, **kwargs):
         context = super(CategoryDetail, self).get_context_data(**kwargs)
         context["heading"] = self.category.name
+        context["breadcrumbs"] = [
+            {"name": "Home", "url": "/"},
+            {
+                "name": self.category.name,
+                "url": self.category.get_absolute_url(),
+            },
+        ]
         return context
 
 
@@ -591,6 +603,27 @@ class RegionDetail(ArticleList):
         ]
         context["title"] = str(self.region).rpartition("/")[2]
         context["heading"] = "|".join(regions)
+
+        # Breadcrumbs -- home > region hierarchy
+        chain = []
+        name = self.region.name
+        while name:
+            chain.append(name)
+            name = name.rpartition("/")[0]
+        chain.reverse()
+        breadcrumbs = [{"name": "Home", "url": "/"}]
+        for full_name in chain:
+            try:
+                ancestor = models.Region.objects.get(name=full_name)
+            except models.Region.DoesNotExist:
+                continue
+            breadcrumbs.append(
+                {
+                    "name": ancestor.name.rpartition("/")[2],
+                    "url": ancestor.get_absolute_url(),
+                }
+            )
+        context["breadcrumbs"] = breadcrumbs
         return context
 
 
@@ -622,6 +655,11 @@ class TopicDetail(ArticleList):
         context = super(TopicDetail, self).get_context_data(**kwargs)
         context["heading"] = self.topic.name.upper()
         context["topic"] = self.topic
+        context["breadcrumbs"] = [
+            {"name": "Home", "url": "/"},
+            {"name": "Topics", "url": reverse("newsroom:topic.list")},
+            {"name": self.topic.name, "url": self.topic.get_absolute_url()},
+        ]
         return context
 
     def get_template_names(self):
@@ -767,9 +805,19 @@ def get_context(article):
     else:
         display_region = ""
 
+    breadcrumbs = [
+        {"name": "Home", "url": "/"},
+        {
+            "name": article.category.name,
+            "url": article.category.get_absolute_url(),
+        },
+        {"name": strip_tags(article.title), "url": article.get_absolute_url()},
+    ]
+
     try:
         dict = {
             "article": article,
+            "breadcrumbs": breadcrumbs,
             "display_region": display_region,
             "recommended": article.get_recommended(),
             "related": article.get_related(),

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load seo_tags %}
 
 <!DOCTYPE html>
 
@@ -89,6 +90,7 @@
             <meta name="robots" content="max-video-preview:-1">
             <!-- RSS Feed link -->
             <link rel="alternate" type="application/rss+xml" href="https://www.groundup.org.za/sitenews/rss/" />
+            {% organization_jsonld %}
         {% endblock %}
 
         {% block analytics %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,11 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block title %} | GroundUp{% endblock %}</title>
 
+        {% block canonical %}
+            <link rel="canonical"
+                  href="{{ request.scheme }}://{{ request.get_host }}{{ request.path }}"/>
+        {% endblock %}
+
         {% comment %}
         <link href="https://use.fontawesome.com/releases/v5.0.8/css/all.css" rel="stylesheet">
         <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/templates/seo/breadcrumbs.html
+++ b/templates/seo/breadcrumbs.html
@@ -1,0 +1,15 @@
+{% load seo_tags %}
+{% if breadcrumbs %}
+    <nav class="gu-breadcrumbs" aria-label="Breadcrumb">
+        <ol>
+            {% for crumb in breadcrumbs %}
+                {% if forloop.last or not crumb.url %}
+                    <li><span aria-current="page">{{ crumb.name }}</span></li>
+                {% else %}
+                    <li><a href="{{ crumb.url }}">{{ crumb.name }}</a></li>
+                {% endif %}
+            {% endfor %}
+        </ol>
+    </nav>
+    {% breadcrumb_jsonld breadcrumbs %}
+{% endif %}


### PR DESCRIPTION
This pull request implements structured data for SEO, focusing on adding JSON-LD for breadcrumbs, articles, and organization, and displaying navigational breadcrumbs across key templates. It introduces a new `seo_tags` template tag library, updates context data in views to provide breadcrumb trails, and ensures the structured data is rendered in the relevant HTML pages. Styling for breadcrumbs is also added.

**SEO Structured Data and Breadcrumbs**

* Added a new `seo_tags` template tag library (`newsroom/templatetags/seo_tags.py`) that provides tags for JSON-LD structured data: `organization_jsonld`, `breadcrumb_jsonld`, and `news_article_jsonld`, implementing schema.org standards for NewsArticle, BreadcrumbList, and Organization.
* Inserted JSON-LD structured data for articles (`news_article_jsonld`) and organization (`organization_jsonld`) in `article_detail.html` and `base.html`, respectively. [[1]](diffhunk://#diff-b7932f24aee6614545551effb4afdd092e36ed3ded4620ca16db34b8b3cca526R5) [[2]](diffhunk://#diff-b7932f24aee6614545551effb4afdd092e36ed3ded4620ca16db34b8b3cca526R46-R47) [[3]](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eR2) [[4]](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eR93)

**Breadcrumb Navigation**

* Added breadcrumb navigation to article, author, topic, and article list templates by including `seo/breadcrumbs.html`, which renders visible (but hidden by default) breadcrumbs and outputs the JSON-LD BreadcrumbList. [[1]](diffhunk://#diff-95b05f3c141e469703728a7a08b852982b9195fa5b61c42ef7d1a577f93da34bR60) [[2]](diffhunk://#diff-8b1efc4a8147b0ac70fbabbb36eee8580499d85ef84dab21a395809db2b793baR11) [[3]](diffhunk://#diff-a4cc6769dbadc870f468fc63d7e3cd765d691dda471bd87d9aa1ac63ae4b2320R11) [[4]](diffhunk://#diff-0c0ea4d47f0fc2ad1aebf0e10f3ae82a00a3f36783e730b0b2b3308040b28317R10) [[5]](diffhunk://#diff-d0a3a61d3a5a02318441e1e25d6fd2336ed6b926e594f2eb40f11a9ad53c13b0R1-R15)
* Populated the `breadcrumbs` context variable in views for articles, authors, topics, categories, and regions to provide the breadcrumb trail structure for templates. [[1]](diffhunk://#diff-fea0b48d32f44265a14857295d4be268efc67ecfac5bd078a73b70a0db094a30R525-R529) [[2]](diffhunk://#diff-fea0b48d32f44265a14857295d4be268efc67ecfac5bd078a73b70a0db094a30R545-R551) [[3]](diffhunk://#diff-fea0b48d32f44265a14857295d4be268efc67ecfac5bd078a73b70a0db094a30R606-R626) [[4]](diffhunk://#diff-fea0b48d32f44265a14857295d4be268efc67ecfac5bd078a73b70a0db094a30R658-R662) [[5]](diffhunk://#diff-fea0b48d32f44265a14857295d4be268efc67ecfac5bd078a73b70a0db094a30R808-R820)

**Styling**

* Added CSS for `.gu-breadcrumbs` to style the breadcrumb navigation and ensure it is presentationally hidden by default, but accessible for SEO and screen readers.

**Article Model Enhancement**

* Added a `get_authors` method to the `NewsArticle` model to return non-null author objects, supporting the structured author list in NewsArticle JSON-LD.

**Other Improvements**

* Added a canonical link block to `base.html` to improve SEO by specifying the preferred URL for each page.