### PR TITLE
feat(styles): add h3 and h4 headings for use in articles

### DIFF
--- a/agony/admin.py
+++ b/agony/admin.py
@@ -51,7 +51,7 @@ class QandAAdmin(admin.ModelAdmin):
         css = {'all': ('/static/newsroom/css/admin_enhance.css', )}
         js = [
             '//cdn.ckeditor.com/4.11.2/standard-all/ckeditor.js',
-            '/static/newsroom/js/ck_styles.js',
+            '/static/newsroom/js/ck_styles.js?v=20260721',
             '/static/newsroom/js/ck_init_admin.js',
         ]
 

--- a/newsroom/admin.py
+++ b/newsroom/admin.py
@@ -290,7 +290,7 @@ class ArticleAdmin(admin.ModelAdmin):
         css = {"all": ("/static/newsroom/css/admin_enhance.css",)}
         js = [
             "//cdn.ckeditor.com/4.14.0/standard-all/ckeditor.js",
-            "/static/newsroom/js/ck_styles.js?v=20220203",
+            "/static/newsroom/js/ck_styles.js?v=20260721",
             "/static/newsroom/js/ck_init_admin.js?v=20220203",
             "/static/newsroom/js/statistics.js?v=20220203",
             "/static/newsroom/js/admin_enhance.js?v=20220203",
@@ -466,7 +466,7 @@ class FlatPageAdmin(FlatPageAdmin):
         css = {"all": ("/static/newsroom/css/admin_enhance.css",)}
         js = [
             "//cdn.ckeditor.com/4.14.0/standard-all/ckeditor.js",
-            "/static/newsroom/js/ck_styles.js",
+            "/static/newsroom/js/ck_styles.js?v=20260721",
             "/static/newsroom/js/ck_init_admin.js",
         ]
 

--- a/newsroom/static/newsroom/css/ckeditor_styles.css
+++ b/newsroom/static/newsroom/css/ckeditor_styles.css
@@ -49,6 +49,18 @@ body {
     font-size: 1.4rem;
 }
 
+h3 {
+    margin-top: 16px;
+    margin-bottom: 14px;
+    font-size: 1.2rem;
+}
+
+h4 {
+    margin-top: 16px;
+    margin-bottom: 14px;
+    font-size: 1.05rem;
+}
+
 .author-description {
     font-style: italic;
 }

--- a/newsroom/static/newsroom/js/ck_styles.js
+++ b/newsroom/static/newsroom/js/ck_styles.js
@@ -18,4 +18,6 @@ CKEDITOR.stylesSet.add( 'gu_styles', [
       attributes: { 'class': 'soundcloud'}},
     { name: 'Subheading', element: 'h2',
       attributes: { 'class': 'subheading' } },
+    { name: 'Subheading 2', element: 'h3' },
+    { name: 'Subheading 3', element: 'h4' },
 ] );

--- a/newsroom/templates/newsroom/article.css
+++ b/newsroom/templates/newsroom/article.css
@@ -184,6 +184,22 @@ ul:nth-child(3) > li {
     font-size: 2.4rem;
 }
 
+#article_body h3 {
+    font-family: Inter,  san-serif;
+    margin-top: 26px;
+    margin-bottom: 14px;
+    font-weight: bold;
+    font-size: 2.1rem;
+}
+
+#article_body h4 {
+    font-family: Inter,  san-serif;
+    margin-top: 22px;
+    margin-bottom: 14px;
+    font-weight: bold;
+    font-size: 1.9rem;
+}
+
 #article__correction {
     margin-top: 12px;
     margin-bottom: 12px;
@@ -621,6 +637,18 @@ article figure, article p.caption {
         margin-left: 100px;
         margin-right: 100px;
         font-size: 2.7rem !important;
+    }
+
+    #article_body h3 {
+        margin-left: 100px;
+        margin-right: 100px;
+        font-size: 2.4rem !important;
+    }
+
+    #article_body h4 {
+        margin-left: 100px;
+        margin-right: 100px;
+        font-size: 2.2rem !important;
     }
 
     #article_body .editor-summary h2, h2.editor-summary  {

--- a/newsroom/templates/newsroom/article_detail.html
+++ b/newsroom/templates/newsroom/article_detail.html
@@ -58,7 +58,7 @@
     {% if can_edit %}
         <script src="{% static 'newsroom/js/statistics.js' %}"></script>
         <script src="https://cdn.ckeditor.com/4.17.1/full-all/ckeditor.js"></script>
-        <script src="{% static 'newsroom/js/ck_styles.js' %}?v=20220203"></script>
+        <script src="{% static 'newsroom/js/ck_styles.js' %}?v=20260721"></script>
         <script src="{% static 'newsroom/js/ck_init.js' %}?v=20220211b"></script>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
     {% endif %}


### PR DESCRIPTION
This pull request introduces support for new heading styles (`h3` and `h4`) in the article editor, updates their appearance in both the editor and published articles, and ensures cache busting for the related JavaScript file. The changes improve the flexibility of content formatting and ensure style consistency across the editing and viewing experiences.

**Support for new heading styles:**

* Added `Subheading 2` (`h3`) and `Subheading 3` (`h4`) to the CKEditor styles set in `ck_styles.js`, allowing editors to use these headings in articles.
* Updated `ckeditor_styles.css` to style `h3` and `h4` elements in the editor for better visual feedback.

**Styling for published articles:**

* Added CSS rules for `#article_body h3` and `#article_body h4` in `article.css` to define their font, size, and margins, ensuring consistent display in published articles.
* Enhanced responsive styles for `h3` and `h4` headings in `article.css` to maintain readability on larger screens.

**Cache busting for editor scripts:**

* Updated references to `ck_styles.js` across admin and article templates and configurations to use a new version query string (`?v=20260721`), ensuring browsers load the latest script changes. [[1]](diffhunk://#diff-c517ad2d33244b6e4dd0fdb5575c9a418e198eddb1e939510dd20062941495bcL54-R54) [[2]](diffhunk://#diff-96f6b186c0dce5f3c0741fb0d91718db6aefb8d6200a53c690309839050f3c00L293-R293) [[3]](diffhunk://#diff-96f6b186c0dce5f3c0741fb0d91718db6aefb8d6200a53c690309839050f3c00L469-R469) [[4]](diffhunk://#diff-b7932f24aee6614545551effb4afdd092e36ed3ded4620ca16db34b8b3cca526L61-R61)