### PR TITLE
Update donor dashboard link and access instructions in email template

### DIFF
--- a/donationPage/management/commands/PullDonations.py
+++ b/donationPage/management/commands/PullDonations.py
@@ -4,7 +4,9 @@ import random
 import pytz
 import re
 from django.core.mail import send_mail
+from django.core.signing import TimestampSigner
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.html import strip_tags
 from datetime import datetime, timezone, timedelta
 from requests.auth import HTTPBasicAuth
@@ -14,6 +16,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.contrib.sites.models import Site
 from donationPage.utils import make_donorUrl
 
+signer = TimestampSigner()
+
 
 def handle_transaction(donor_email, donor_name, transaction_datetime, amount, currency_type, notified, count):
         count=count
@@ -21,7 +25,7 @@ def handle_transaction(donor_email, donor_name, transaction_datetime, amount, cu
             Cdonor=Donor.objects.get(email=donor_email)
         except:
         #create new donor entry if not, and set Cdonor value to newDonor data
-            url=make_donorUrl(transaction_datetime).replace("UTC","")
+            url=make_donorUrl()
             newDonor = Donor(email=donor_email, name=donor_name, display_name='Anonymous', donor_url=url)
             newDonor.save()
             Cdonor=newDonor
@@ -39,9 +43,14 @@ def handle_transaction(donor_email, donor_name, transaction_datetime, amount, cu
                 if is_valid_email(donor_email):
                     # Send the email with the unique link
                     subject = 'Thank you for your donation to GroundUp'
-                    email_url = site+"/donation/"+Cdonor.donor_url
-                    donation_url = site+"/donation/donations"
-                    message = render_to_string('donationPage/email_template.html', {'unique_link': email_url, 'donor_name': donor_name, 'donation_link': donation_url})
+                    # signed, time-limited link to the donor dashboard
+                    # (expires after 24 hours!! see donor_dashboard_view)
+                    dashboard_url = site + reverse(
+                        'donor_dashboard',
+                        kwargs={'token': signer.sign(Cdonor.donor_url)})
+                    access_url = site + reverse('donor_access')
+                    donation_url = site + reverse('donation.page')
+                    message = render_to_string('donationPage/email_template.html', {'unique_link': dashboard_url, 'donor_name': donor_name, 'donation_link': donation_url, 'access_link': access_url})
                     plain_message = strip_tags(message)
                 
                     send_mail(subject, plain_message, settings.DEFAULT_FROM_EMAIL, [donor_email], html_message=message)

--- a/donationPage/templates/donationPage/email_template.html
+++ b/donationPage/templates/donationPage/email_template.html
@@ -10,7 +10,8 @@
     <p>Thank you for donating to GroundUp!</p>
     <br>
     <p>Your donation is tax-deductible in the Republic of South Africa. Please send an email to donations@groundup.org.za to request your Section 18A tax certificate.</p>
-    <p>Here is your unique link to update your details: <a href="{{ unique_link }}">{{ unique_link }}</a></p>
+    <p>Here is your link to your donor dashboard, where you can update your details and view your donations: <a href="{{ unique_link }}">{{ unique_link }}</a></p>
+    <p>This link expires after 24 hours. If it has expired, you can request a new one at <a href="{{ access_link }}">{{ access_link }}</a>.</p>
     <br>
     <p>You can find a list of our donations at: <a href="{{ donation_link }}">{{ donation_link }}</a></p>
     <br>


### PR DESCRIPTION
This pull request updates the donor notification process to improve security and user experience by introducing time-limited, signed links for donor dashboard access, and updating the email template accordingly. The changes ensure that donor dashboard links expire after 24 hours and provide a way for donors to request a new link if needed.

**Donor dashboard access and email improvements:**

* Added use of `TimestampSigner` to generate signed, time-limited tokens for donor dashboard URLs, enhancing security by ensuring links expire after 24 hours (`donationPage/management/commands/PullDonations.py`). [[1]](diffhunk://#diff-6d42167d936f1e5264cd895c5f4c91ea580cc3f19acc19fbd92a3d1f631f4a14R7-R9) [[2]](diffhunk://#diff-6d42167d936f1e5264cd895c5f4c91ea580cc3f19acc19fbd92a3d1f631f4a14L42-R53)
* Updated the donor email template to clarify that the dashboard link expires after 24 hours and included instructions and a link for requesting a new access link (`donationPage/templates/donationPage/email_template.html`).
* Changed the construction of URLs in the email to use Django's `reverse` function for improved maintainability and accuracy (`donationPage/management/commands/PullDonations.py`).

**Code cleanup and minor fixes:**

* Refactored donor URL generation to remove the unused `transaction_datetime` parameter, simplifying the code (`donationPage/management/commands/PullDonations.py`).