### PR TITLE
Implement GroundUp Puzzles block with caching and placeholders

### DIFF
--- a/blocks/puzzles.py
+++ b/blocks/puzzles.py
@@ -1,0 +1,171 @@
+"""Data for the GroundUp Puzzles block."""
+
+import logging
+
+import requests
+from django.conf import settings
+from django.core.cache import cache
+from django.urls import reverse
+
+from target.models import Target
+
+logger = logging.getLogger("django")
+
+CACHE_KEY = "puzzles_block:puzzles"
+# The last answer that worked (we chache)
+STALE_KEY = "puzzles_block:puzzles:last_good"
+STALE_SECONDS = 24 * 60 * 60
+RETRY_SECONDS = 60
+
+
+def _fetch():
+    """The puzzles site's puzzles, or None"""
+    url = settings.PUZZLES_API_URL
+    try:
+        response = requests.get(
+            url,
+            timeout=settings.PUZZLES_API_TIMEOUT,
+            headers={"Accept": "application/json"},
+        )
+        response.raise_for_status()
+        puzzles = response.json()["puzzles"]
+    except (requests.RequestException, ValueError, KeyError, TypeError):
+        logger.warning("Puzzles block: could not read %s", url, exc_info=True)
+        return None
+    if not isinstance(puzzles, dict):
+        logger.warning("Puzzles block: unexpected payload from %s", url)
+        return None
+    return puzzles
+
+
+def remote_puzzles():
+    """Cached puzzles from the puzzles site."""
+    puzzles = cache.get(CACHE_KEY)
+    if puzzles is not None:
+        return puzzles
+    puzzles = _fetch()
+    if puzzles is None:
+        puzzles = cache.get(STALE_KEY) or {}
+        cache.set(CACHE_KEY, puzzles, RETRY_SECONDS)
+        return puzzles
+    cache.set(CACHE_KEY, puzzles, settings.PUZZLES_API_CACHE_SECONDS)
+    cache.set(STALE_KEY, puzzles, STALE_SECONDS)
+    return puzzles
+
+
+def local_target():
+    """The newest published Target
+
+    The letters are stored centre-first, which isn't the order they're
+    drawn in, so this puts the centre back in the middle.
+    """
+    target = Target.objects.published().order_by("-published").first()
+    if target is None:
+        return None
+    outer = list(target.letters[1:])
+    letters = outer[:4] + [target.letters[0]] + outer[4:]
+    return {
+        "available": True,
+        "url": reverse("target:latest"),
+        "title": "Target #%s" % target.number if target.number else "Target",
+        "cells": [
+            {"char": char.upper(), "centre": index == 4}
+            for index, char in enumerate(letters)
+        ],
+    }
+
+
+# Placeholders (when the puzzles server is burning)
+ARCHIVE_PATHS = {"crossword": "/crossword/", "sudoku": "/sudoku/"}
+
+PLACEHOLDER_SIZE = 9
+
+PLACEHOLDER_BLOCKS = (
+    "...#....."
+    "...#..#.."
+    "......#.."
+    "##...#..."
+    "...###..."
+    "...#...##"
+    "..#......"
+    "..#..#..."
+    ".....#..."
+)
+
+PLACEHOLDER_GIVENS = (
+    "4...6...."
+    "..9.3...6"
+    "...3..7.8"
+    ".8..2..7."
+    "..36.51.."
+    ".2..7..5."
+    "1.7..4..."
+    "5...1.2.."
+    "....8...9"
+)
+
+
+def _puzzles_site_url(path):
+    return settings.PUZZLES_SITE_URL.rstrip("/") + path
+
+
+def _crossword_placeholder():
+    """A 9x9 grid, unnumbered"""
+    grid = [
+        [
+            {
+                "block": PLACEHOLDER_BLOCKS[row * PLACEHOLDER_SIZE + col] == "#",
+                "number": None,
+            }
+            for col in range(PLACEHOLDER_SIZE)
+        ]
+        for row in range(PLACEHOLDER_SIZE)
+    ]
+    return {
+        "placeholder": True,
+        "url": _puzzles_site_url(ARCHIVE_PATHS["crossword"]),
+        "num_rows": PLACEHOLDER_SIZE,
+        "num_cols": PLACEHOLDER_SIZE,
+        "grid": grid,
+    }
+
+
+def _sudoku_placeholder():
+    return {
+        "placeholder": True,
+        "url": _puzzles_site_url(ARCHIVE_PATHS["sudoku"]),
+        "cells": [c if c != "." else "" for c in PLACEHOLDER_GIVENS],
+    }
+
+
+def _target_placeholder():
+    return {
+        "placeholder": True,
+        "url": reverse("target:list"),
+        "title": "Target",
+        "cells": [
+            {"char": char, "centre": index == 4}
+            for index, char in enumerate("GROUNDUPS")
+        ],
+    }
+
+
+def _resolve(teaser, placeholder):
+    """The real teaser if we have one; generic if we don't."""
+    if teaser and teaser.get("available"):
+        return teaser
+    return placeholder
+
+
+def puzzles_block_context():
+    """Everything the GroundUp Puzzles block template renders."""
+    puzzles = remote_puzzles()
+    return {
+        "crossword": _resolve(puzzles.get("crossword"), _crossword_placeholder()),
+        "sudoku": _resolve(puzzles.get("sudoku"), _sudoku_placeholder()),
+        # Prefer Target from the API (TODO: remiove when we sort out target on puzzles)
+        "target": _resolve(
+            puzzles.get("target") or local_target(), _target_placeholder()
+        ),
+        "puzzles_url": settings.PUZZLES_SITE_URL,
+    }

--- a/blocks/templates/blocks/blocks.html
+++ b/blocks/templates/blocks/blocks.html
@@ -18,6 +18,7 @@ For Quick Links on the home page edit the ProfiledLinks block in the admin front
 {% endcomment %}
 
 {% load newsroom_extras %}
+{% load puzzles_extras %}
 
 {% for b in blocks %}
     <div class="sidebar-block">
@@ -103,6 +104,8 @@ For Quick Links on the home page edit the ProfiledLinks block in the admin front
 	    <div id="qanda">
 	        {% include 'agony/qanda_snippet.html' %}
 	    </div>
+        {% elif b.name == "_Puzzles" %}
+            {% puzzles_block %}
         {% elif b.name == "_Target_Sudoku" %}
             <section class="home-shortcode-block">
                 <h3 class="shortcode-heading">

--- a/blocks/templates/blocks/puzzles_block.css
+++ b/blocks/templates/blocks/puzzles_block.css
@@ -1,0 +1,399 @@
+.gup {
+    --gup-ink: #151f22;
+    --gup-rule: #e3e3dc;
+    --gup-muted: #5a6266;
+    --gup-dim: #9a9a9a;
+    --gup-link: #0250bb;
+    --accent: #00b1f0;
+    --accent-deep: #0091c6;
+    --accent-soft: #e2f5fd;
+
+    display: block;
+    margin: 0 0 28px;
+    font-family: Inter, "Helvetica Neue", Arial, sans-serif;
+    color: var(--gup-ink);
+}
+
+.gup * { box-sizing: border-box; }
+
+.gup .gup-t-crossword { --accent: #00b1f0; --accent-deep: #0086b8; --accent-soft: #e6f6fd; }
+.gup .gup-t-sudoku    { --accent: #4d57c4; --accent-deep: #3b44a8; --accent-soft: #eeeff9; }
+.gup .gup-t-target    { --accent: #1f8a5b; --accent-deep: #19714a; --accent-soft: #e9f4ee; }
+.gup .gup-t-quiz      { --accent: #d4582f; --accent-deep: #b8461f; --accent-soft: #fcefe9; }
+
+/* section head */
+.gup .gup__head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 2px 16px;
+    margin: 0 0 18px;
+    padding: 0 0 10px;
+    border-bottom: 3px solid var(--gup-ink);
+}
+
+.gup .gup__title {
+    margin: 0;
+    padding: 0;
+    font-family: inherit;
+    font-size: 26px;
+    line-height: 1.1;
+    font-weight: 700;
+    letter-spacing: -.6px;
+    text-transform: none;
+    color: var(--gup-ink);
+}
+
+.gup .gup__all {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--gup-link);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.gup .gup__all:hover,
+.gup .gup__all:focus { text-decoration: underline; }
+
+/* the cards*/
+
+.gup .gup-card {
+    display: block;
+    border: 1px solid var(--gup-rule);
+    border-top: 4px solid var(--accent);
+    background: #fff;
+    color: inherit;
+    text-decoration: none;
+}
+
+.gup a.gup-card:hover,
+.gup a.gup-card:focus {
+    border-color: var(--accent);
+    border-top-color: var(--accent);
+    text-decoration: none;
+}
+
+/* featured puzzle! */
+.gup .gup-hero {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    margin: 0 0 18px;
+}
+
+.gup .gup-hero__art {
+    flex: 0 1 232px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 22px;
+    background: var(--accent-soft);
+}
+
+.gup .gup-hero__text {
+    flex: 1 1 264px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 22px 24px;
+}
+
+.gup .gup-hero__tags {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 9px;
+}
+
+.gup .gup-hero__name {
+    margin: 0 0 7px;
+    padding: 0;
+    font-family: inherit;
+    font-size: 28px;
+    line-height: 1.05;
+    font-weight: 700;
+    letter-spacing: -.8px;
+    text-transform: none;
+    color: var(--gup-ink);
+}
+
+.gup .gup-hero__blurb {
+    margin: 0 0 18px;
+    font-size: 15px;
+    line-height: 1.45;
+    color: var(--gup-muted);
+}
+
+
+.gup .gup-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(158px, 1fr));
+    gap: 16px;
+}
+
+.gup .gup-tile { display: flex; flex-direction: column; }
+
+.gup .gup-tile__art {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 134px;
+    padding: 18px;
+    background: var(--accent-soft);
+}
+
+.gup .gup-tile__body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 14px 15px 15px;
+}
+
+.gup .gup-tile__name {
+    margin: 0 0 4px;
+    padding: 0;
+    font-family: inherit;
+    font-size: 17px;
+    line-height: 1.15;
+    font-weight: 700;
+    letter-spacing: -.2px;
+    text-transform: none;
+    color: var(--gup-ink);
+}
+
+.gup .gup-tile__blurb {
+    margin: 0 0 13px;
+    font-size: 13px;
+    line-height: 1.35;
+    color: var(--gup-muted);
+}
+
+.gup .gup-tile__foot {
+    margin-top: auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.gup .gup-tile__play {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--accent-deep);
+}
+
+/* The quiz forgoes the accent edge and tint until it launches: the
+   colour is what says "this one you can play". */
+.gup .gup-tile--soon {
+    border-top-color: var(--gup-rule);
+    border-style: dashed;
+    background: #fbfbfa;
+}
+
+.gup .gup-tile--soon .gup-tile__art { background: none; }
+
+.gup .gup-tile--soon .gup-tile__name,
+.gup .gup-tile--soon .gup-tile__blurb { color: var(--gup-dim); }
+
+.gup .gup-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--accent-deep);
+}
+
+.gup .gup-badge {
+    display: inline-block;
+    padding: 2px 9px;
+    border: 1px solid var(--accent);
+    border-radius: 10px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: var(--accent-deep);
+}
+
+.gup .gup-badge--solid {
+    border-radius: 3px;
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+.gup .gup-badge--quiet {
+    border-color: #d2d2d2;
+    color: var(--gup-dim);
+}
+
+.gup .gup-btn {
+    display: inline-block;
+    padding: 11px 22px;
+    background: var(--accent);
+    border: none;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.2;
+    text-decoration: none;
+}
+
+.gup .gup-hero:hover .gup-btn,
+.gup .gup-hero:focus .gup-btn { filter: brightness(.92); }
+
+.gup .gup-mini {
+    display: grid;
+    grid-template-columns: repeat(var(--cols, 13), 1fr);
+    gap: 1px;
+    width: min(100%, 196px);
+    min-width: 0;
+    background: var(--gup-ink);
+    border: 2px solid var(--gup-ink);
+}
+
+.gup .gup-mini span {
+    position: relative;
+    aspect-ratio: 1;
+    background: #fff;
+}
+
+.gup .gup-mini span.is-block { background: var(--gup-ink); }
+
+.gup .gup-mini b {
+    position: absolute;
+    top: 1px;
+    left: 2px;
+    font-size: 7px;
+    font-weight: 600;
+    line-height: 1;
+    color: #8c8c8c;
+}
+
+.gup .gup-sudoku {
+    display: grid;
+    grid-template-columns: repeat(9, 1fr);
+    /* Rows need declaring too, or the last one spills past the border. */
+    grid-template-rows: repeat(9, 1fr);
+    width: 102px;
+    height: 102px;
+    background: #fff;
+    border: 1.5px solid var(--gup-ink);
+    overflow: hidden;
+}
+
+.gup .gup-sudoku span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    min-height: 0;
+    font-size: 8px;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--gup-ink);
+    border-right: 1px solid #dcdce6;
+    border-bottom: 1px solid #dcdce6;
+}
+
+.gup .gup-sudoku span:nth-child(9n) { border-right: 0; }
+.gup .gup-sudoku span:nth-child(3n):not(:nth-child(9n)) { border-right: 1px solid var(--accent); }
+.gup .gup-sudoku span:nth-child(n+73) { border-bottom: 0; }
+.gup .gup-sudoku span:nth-child(n+19):nth-child(-n+27),
+.gup .gup-sudoku span:nth-child(n+46):nth-child(-n+54) { border-bottom: 1px solid var(--accent); }
+
+.gup .gup-letters {
+    display: grid;
+    grid-template-columns: repeat(3, 31px);
+    gap: 4px;
+}
+
+.gup .gup-letters span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 31px;
+    height: 31px;
+    background: #fff;
+    border: 1px solid #dcdcd4;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--gup-ink);
+}
+
+.gup .gup-letters span.is-centre {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+.gup .gup-quiz {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 102px;
+}
+
+.gup .gup-quiz span {
+    position: relative;
+    height: 16px;
+    background: #fff;
+    border: 1px solid #e4e4e4;
+    border-radius: 3px;
+}
+
+.gup .gup-quiz span::before {
+    content: "";
+    position: absolute;
+    left: 4px;
+    top: 50%;
+    width: 7px;
+    height: 7px;
+    margin-top: -4px;
+    border: 1px solid #d4d4d4;
+    border-radius: 50%;
+}
+
+.gup .gup-quiz span:first-child {
+    width: 88%;
+    height: 11px;
+    background: #dcdcdc;
+    border: none;
+}
+
+.gup .gup-quiz span:first-child::before { content: none; }
+
+.gup .gup-quiz span.is-picked { border-color: #c8c8c8; }
+.gup .gup-quiz span.is-picked::before { background: #b8b8b8; border-color: #b8b8b8; }
+
+@supports (container-type: inline-size) {
+    .gup { container-type: inline-size; }
+}
+
+@container (max-width: 460px) {
+    .gup .gup-tiles {
+        display: flex;
+        overflow-x: auto;
+        scroll-snap-type: x proximity;
+        scrollbar-width: thin;
+        padding-bottom: 6px;
+        gap: 14px;
+    }
+
+    .gup .gup-tiles > * {
+        flex: 0 0 min(76%, 240px);
+        scroll-snap-align: start;
+    }
+
+    .gup .gup-hero__art { flex-basis: 100%; padding: 20px 18px; }
+    .gup .gup-mini { width: min(100%, 224px); }
+    .gup .gup-hero__text { padding: 18px 18px 20px; }
+    .gup .gup-hero__name { font-size: 25px; }
+}

--- a/blocks/templates/blocks/puzzles_block.html
+++ b/blocks/templates/blocks/puzzles_block.html
@@ -1,0 +1,84 @@
+{% comment %}
+The GroundUp Puzzles block, rendered by {% puzzles_block %}. Data comes
+from blocks/puzzles.py.
+{% endcomment %}
+
+<style>{% include "blocks/puzzles_block.css" %}</style>
+
+<section class="gup">
+    <header class="gup__head">
+        <h3 class="gup__title">GroundUp Puzzles</h3>
+        <a class="gup__all" href="{{ puzzles_url }}">All puzzles &rsaquo;</a>
+    </header>
+
+    <a class="gup-card gup-hero gup-t-crossword" href="{{ crossword.url }}">
+        <div class="gup-hero__art">
+            <div class="gup-mini" style="--cols:{{ crossword.num_cols }}" aria-hidden="true">
+                {% for row in crossword.grid %}{% for cell in row %}<span{% if cell.block %} class="is-block"{% endif %}>{% if cell.number %}<b>{{ cell.number }}</b>{% endif %}</span>{% endfor %}{% endfor %}
+            </div>
+        </div>
+        <div class="gup-hero__text">
+            <div class="gup-hero__tags">
+                <span class="gup-label">Crossword</span>
+                {% if not crossword.placeholder %}
+                <span class="gup-badge gup-badge--solid">New</span>
+                <span class="gup-badge">{{ crossword.num_cols }} &times; {{ crossword.num_rows }}</span>
+                {% endif %}
+            </div>
+            <h4 class="gup-hero__name">{% if crossword.placeholder %}Crosswords{% else %}{{ crossword.title }}{% endif %}</h4>
+            <p class="gup-hero__blurb">{% if crossword.description and not crossword.placeholder %}{{ crossword.description|truncatewords:22 }}{% else %}A cryptic-ish grid with a South African twist.{% endif %}</p>
+            <span class="gup-btn">{% if crossword.placeholder %}Browse the crosswords{% else %}Play the crossword{% endif %} &rarr;</span>
+        </div>
+    </a>
+
+    <div class="gup-tiles">
+
+        <a class="gup-card gup-tile gup-t-sudoku" href="{{ sudoku.url }}">
+            <div class="gup-tile__art">
+                <div class="gup-sudoku" aria-hidden="true">
+                    {% for digit in sudoku.cells %}<span>{{ digit }}</span>{% endfor %}
+                </div>
+            </div>
+            <div class="gup-tile__body">
+                <h4 class="gup-tile__name">Sudoku</h4>
+                <p class="gup-tile__blurb">Fill every row, column and box with one to nine.</p>
+                <div class="gup-tile__foot">
+                    <span class="gup-badge">{% if sudoku.placeholder %}Daily{% else %}{{ sudoku.difficulty|default:"Daily" }}{% endif %}</span>
+                    <span class="gup-tile__play">{% if sudoku.placeholder %}Browse{% else %}Play{% endif %} &rsaquo;</span>
+                </div>
+            </div>
+        </a>
+
+        <a class="gup-card gup-tile gup-t-target" href="{{ target.url }}">
+            <div class="gup-tile__art">
+                <div class="gup-letters" aria-hidden="true">
+                    {% for cell in target.cells %}<span{% if cell.centre %} class="is-centre"{% endif %}>{{ cell.char }}</span>{% endfor %}
+                </div>
+            </div>
+            <div class="gup-tile__body">
+                <h4 class="gup-tile__name">{{ target.title }}</h4>
+                <p class="gup-tile__blurb">Nine letters. How many words can you find?</p>
+                <div class="gup-tile__foot">
+                    <span class="gup-badge">Mon &amp; Fri</span>
+                    <span class="gup-tile__play">{% if target.placeholder %}Browse{% else %}Play{% endif %} &rsaquo;</span>
+                </div>
+            </div>
+        </a>
+
+        <div class="gup-card gup-tile gup-tile--soon gup-t-quiz">
+            <div class="gup-tile__art">
+                <div class="gup-quiz" aria-hidden="true">
+                    <span></span><span></span><span class="is-picked"></span><span></span>
+                </div>
+            </div>
+            <div class="gup-tile__body">
+                <h4 class="gup-tile__name">News Quiz</h4>
+                <p class="gup-tile__blurb">Questions on the week's news.</p>
+                <div class="gup-tile__foot">
+                    <span class="gup-badge gup-badge--quiet">Coming soon</span>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</section>

--- a/blocks/templatetags/puzzles_extras.py
+++ b/blocks/templatetags/puzzles_extras.py
@@ -1,0 +1,11 @@
+from django import template
+
+from blocks.puzzles import puzzles_block_context
+
+register = template.Library()
+
+
+@register.inclusion_tag("blocks/puzzles_block.html")
+def puzzles_block():
+    """The GroundUp Puzzles block. See blocks/puzzles.py."""
+    return puzzles_block_context()

--- a/blocks/tests.py
+++ b/blocks/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
+from django.urls import reverse
+from django.utils import timezone
 from .models import Group, Block, BlockGroup
 
 class BlockTests(TestCase):
@@ -70,3 +72,187 @@ class BlockTests(TestCase):
         self.assertEqual(len(blocks), 2, "Expected exactly 2 blocks")
         self.assertIn(self.block1, blocks, "First block should be in result")
         self.assertIn(self.block2, blocks, "Second block should be in result")
+
+
+# --------------------------------------------------------------------------
+# The GroundUp Puzzles block. Its teasers arrive over HTTP from another
+# site, so what's worth testing is surviving that site being slow, broken
+# or absent -- plus where each tile points.
+
+from unittest.mock import patch
+
+import requests
+from django.core.cache import cache
+from django.template.loader import render_to_string
+from django.test import override_settings
+
+from blocks import puzzles as puzzles_block
+from target.models import Target
+
+REMOTE = {
+    "puzzles": {
+        "crossword": {
+            "available": True,
+            "url": "https://puzzles.groundup.org.za/crossword/7/solve/",
+            "archive_url": "https://puzzles.groundup.org.za/crossword/",
+            "title": "Cryptic-ish #7",
+            "description": "",
+            "num_rows": 3,
+            "num_cols": 3,
+            "grid": [[{"block": False, "number": 1}] * 3] * 3,
+        },
+        "sudoku": {
+            "available": True,
+            "url": "https://puzzles.groundup.org.za/sudoku/9/",
+            "archive_url": "https://puzzles.groundup.org.za/sudoku/",
+            "title": "Sudoku #9",
+            "number": 9,
+            "difficulty": "Medium",
+            "cells": [""] * 81,
+        },
+    }
+}
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+    PUZZLES_SITE_URL="https://puzzles.groundup.org.za",
+    PUZZLES_API_URL="https://puzzles.groundup.org.za/api/puzzles/",
+    PUZZLES_API_TIMEOUT=2.5,
+    PUZZLES_API_CACHE_SECONDS=300,
+)
+class PuzzlesBlockTests(TestCase):
+
+    def setUp(self):
+        cache.clear()
+        Target.objects.create(
+            letters="EQMAZALNI", words="MAZE", published=timezone.now()
+        )
+
+    def test_crossword_and_sudoku_keep_the_puzzles_site_links(self):
+        with patch("blocks.puzzles.requests.get", return_value=FakeResponse(REMOTE)):
+            context = puzzles_block.puzzles_block_context()
+        self.assertEqual(
+            context["crossword"]["url"],
+            "https://puzzles.groundup.org.za/crossword/7/solve/",
+        )
+        self.assertEqual(
+            context["sudoku"]["url"], "https://puzzles.groundup.org.za/sudoku/9/"
+        )
+
+    def test_target_is_played_here_and_links_here(self):
+        with patch("blocks.puzzles.requests.get", return_value=FakeResponse(REMOTE)):
+            context = puzzles_block.puzzles_block_context()
+        self.assertEqual(context["target"]["url"], reverse("target:latest"))
+        # Centre letter first in the model, middle of the tile on screen.
+        self.assertEqual(
+            [cell["char"] for cell in context["target"]["cells"]],
+            list("QMAZEALNI"),
+        )
+        self.assertTrue(context["target"]["cells"][4]["centre"])
+
+    def test_target_from_the_api_wins_once_it_moves_over(self):
+        payload = {"puzzles": dict(REMOTE["puzzles"], target={"available": True, "url": "x"})}
+        with patch("blocks.puzzles.requests.get", return_value=FakeResponse(payload)):
+            context = puzzles_block.puzzles_block_context()
+        self.assertEqual(context["target"]["url"], "x")
+
+    def test_an_unreachable_puzzles_site_falls_back_to_placeholders(self):
+        with patch("blocks.puzzles.requests.get", side_effect=requests.Timeout):
+            context = puzzles_block.puzzles_block_context()
+        for name in ("crossword", "sudoku"):
+            self.assertTrue(context[name]["placeholder"], name)
+        # Target is ours, so the outage can't touch it.
+        self.assertNotIn("placeholder", context["target"])
+        html = render_to_string("blocks/puzzles_block.html", context)
+        self.assertIn("Puzzles", html)
+        self.assertIn("Coming soon", html)
+
+    def test_placeholders_point_at_the_archives_not_at_a_puzzle(self):
+        with patch("blocks.puzzles.requests.get", side_effect=requests.Timeout):
+            context = puzzles_block.puzzles_block_context()
+        self.assertEqual(
+            context["crossword"]["url"], "https://puzzles.groundup.org.za/crossword/"
+        )
+        self.assertEqual(
+            context["sudoku"]["url"], "https://puzzles.groundup.org.za/sudoku/"
+        )
+
+    def test_a_placeholder_claims_nothing_about_todays_puzzle(self):
+        """A reader clicking through lands on the archive, so nothing on
+        the tile may promise them a particular puzzle."""
+        with patch("blocks.puzzles.requests.get", side_effect=requests.Timeout):
+            context = puzzles_block.puzzles_block_context()
+            html = render_to_string("blocks/puzzles_block.html", context)
+        for name in ("crossword", "sudoku"):
+            for claim in ("title", "number", "difficulty", "published"):
+                self.assertNotIn(claim, context[name], (name, claim))
+        self.assertNotIn(">New<", html)
+        self.assertIn("Browse the crosswords", html)
+        # The artwork still has to be there; an empty tile reads broken.
+        self.assertEqual(len(context["sudoku"]["cells"]), 81)
+        self.assertEqual(len(context["crossword"]["grid"]), 9)
+
+    def test_a_day_with_no_new_puzzle_falls_back_the_same_way(self):
+        payload = {"puzzles": {"crossword": {"available": False}, "sudoku": {"available": False}}}
+        Target.objects.all().delete()
+        with patch("blocks.puzzles.requests.get", return_value=FakeResponse(payload)):
+            context = puzzles_block.puzzles_block_context()
+        for name in ("crossword", "sudoku", "target"):
+            self.assertTrue(context[name]["placeholder"], name)
+        self.assertEqual(context["target"]["url"], reverse("target:list"))
+
+    def test_the_last_good_answer_covers_a_later_outage(self):
+        with patch("blocks.puzzles.requests.get", return_value=FakeResponse(REMOTE)):
+            puzzles_block.puzzles_block_context()
+        cache.delete(puzzles_block.CACHE_KEY)
+        with patch("blocks.puzzles.requests.get", side_effect=requests.Timeout):
+            context = puzzles_block.puzzles_block_context()
+        self.assertEqual(context["crossword"]["title"], "Cryptic-ish #7")
+
+    def test_a_failed_fetch_is_not_retried_on_every_page_view(self):
+        with patch(
+            "blocks.puzzles.requests.get", side_effect=requests.Timeout
+        ) as get:
+            puzzles_block.puzzles_block_context()
+            puzzles_block.puzzles_block_context()
+        self.assertEqual(get.call_count, 1)
+
+    def test_nonsense_from_the_api_is_treated_as_no_answer(self):
+        with patch(
+            "blocks.puzzles.requests.get", return_value=FakeResponse({"puzzles": "oops"})
+        ):
+            context = puzzles_block.puzzles_block_context()
+        self.assertTrue(context["crossword"]["placeholder"])
+
+
+    def test_the_block_is_named_for_puzzles_not_games(self):
+        with patch("blocks.puzzles.requests.get", return_value=FakeResponse(REMOTE)):
+            html = render_to_string(
+                "blocks/puzzles_block.html", puzzles_block.puzzles_block_context()
+            )
+        self.assertIn("GroundUp Puzzles", html)
+        self.assertIn("All puzzles", html)
+        self.assertNotIn("game", html.lower())
+
+    def test_the_quiz_is_marked_coming_soon_and_is_not_a_link(self):
+        with patch("blocks.puzzles.requests.get", return_value=FakeResponse(REMOTE)):
+            html = render_to_string(
+                "blocks/puzzles_block.html", puzzles_block.puzzles_block_context()
+            )
+        self.assertIn("Coming soon", html)
+        self.assertNotIn("quiz_solve", html)
+        # A div, not an anchor: there's nothing to play yet.
+        self.assertRegex(html, r'<div class="[^"]*gup-tile--soon')
+        self.assertNotRegex(html, r'<a class="[^"]*gup-tile--soon')

--- a/groundup/settings.py
+++ b/groundup/settings.py
@@ -469,6 +469,12 @@ S18A_RECEIPT_START = 332
 # address(es) notified when a donor requests an S18A certificate.
 S18A_STAFF_EMAILS = ["info@groundup.org.za"]
 
+# used in api!
+PUZZLES_SITE_URL = "https://puzzles.groundup.org.za"
+PUZZLES_API_URL = PUZZLES_SITE_URL + "/api/puzzles/"
+PUZZLES_API_TIMEOUT = 2.5
+PUZZLES_API_CACHE_SECONDS = 300
+
 
 from .local_settings import *
 


### PR DESCRIPTION
This pull request introduces a new, feature-rich "GroundUp Puzzles" sidebar block to the site, integrating live data from the puzzles API and providing robust fallback behavior. The implementation includes backend logic for fetching and caching puzzle data, template tags for rendering, and a modern, responsive design with dedicated CSS. The block displays the latest Crossword, Sudoku, and Target puzzles (with placeholders if needed), and teases an upcoming News Quiz.

**New GroundUp Puzzles block**

* Backend logic for fetching, caching, and fallback display of puzzles data:
  - Added `blocks/puzzles.py` with functions to fetch puzzles from the API, cache results, provide placeholders, and assemble context for rendering the block.
  - Introduced `puzzles_block_context()` to supply all necessary data for the template.

* Template tag and integration:
  - Added `puzzles_block` inclusion tag in `blocks/templatetags/puzzles_extras.py` to render the block in templates.
  - Updated `blocks/templates/blocks/blocks.html` to load the new tag and render the block when `_Puzzles` is present. [[1]](diffhunk://#diff-7a3ce8e3c1fabe9d87a76edb02252c6221173ca8677d92e091ca424560377aa8R21) [[2]](diffhunk://#diff-7a3ce8e3c1fabe9d87a76edb02252c6221173ca8677d92e091ca424560377aa8R107-R108)

* Front-end and design:
  - Created `blocks/templates/blocks/puzzles_block.html` for the block’s structure, supporting dynamic and placeholder content for all puzzles.
  - Added a comprehensive, responsive CSS file for the block at `blocks/templates/blocks/puzzles_block.css`.

**Testing and support**

* Minor test support improvements:
  - Imported `reverse` and `timezone` in `blocks/tests.py` for potential use in tests.